### PR TITLE
Pin release-action version, add GITHUB_TOKEN permission

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       # Checkout
       - name: Checkout
@@ -19,7 +21,7 @@ jobs:
           ./script/make-zip.sh
 
       - name: Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@cdcc88a9acf3ca41c16c37bb7d21b9ad48560d87  # v1.15.0
         with:
           allowUpdates: true
           artifactErrorsFailBuild: true

--- a/README.md
+++ b/README.md
@@ -87,11 +87,7 @@ least the following files:
 
 ### Use Github Action
 
-1. In your repo setting page `https://github.com/OWNER/REPO/settings/actions`, down to **Workflow Permissions** and open the configuration like this:
-
-    ![](https://github.com/siyuan-note/plugin-sample-vite-svelte/blob/main/asset/action.png?raw=true)
-
-2. Push a tag in the format `v*` and github will automatically create a new release with new bulit package.zip
+Push a tag in the format `v*` and github will automatically create a new release with new bulit package.zip
 
 ## List on the marketplace
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -83,11 +83,7 @@
 
 ### 使用 Github Action 打包
 
-1. 设置项目 `https://github.com/OWNER/REPO/settings/actions` 页面向下划到 **Workflow Permissions**，打开配置
-
-    ![](https://github.com/siyuan-note/plugin-sample-vite-svelte/blob/main/asset/action.png?raw=true)
-
-2. 需要发布版本的时候, push 一个格式为 `v*` 的 tag, github 就会自动打包发布 release（包括 package.zip）
+需要发布版本的时候, push 一个格式为 `v*` 的 tag, github 就会自动打包发布 release（包括 package.zip）
 
 
 ## 上架集市


### PR DESCRIPTION
1. 官方建议将第三方 Actions 版本固定到 SHA256 commit hash 上： [Using third-party actions - Security hardening for GitHub Actions - GitHub Docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
2. 配置 Token 权限，遵循官方规范： [Modifying the permissions for the GITHUB_TOKEN - Automatic token authentication - GitHub Docs](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)
3. 同时简化配置步骤，使用此项目模板的用户不再需要手动配置 Actions 权限了，workflow 帮他们配置好了。